### PR TITLE
Drop `homeUrl` option in favour of a relative path for redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ and then set up your environment in typedoc.json
 
 ---
 
-| Key               | Value Information                                                                                                         | Type     | Required | Default                                                                                       |
-| :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | --------------------------------------------------------------------------------------------- |
-| **_stable_**      | The minor version that you would like to be marked as `stable`                                                            | `string` |  **no**  | The latest minor version of the version being built                                           |
-| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | The latest patch version of the version being built                                           |
-| **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook.                       |
+| Key               | Value Information                                                                                                         | Type     | Required | Default                                                                 |
+| :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ----------------------------------------------------------------------- |
+| **_stable_**      | The minor version that you would like to be marked as `stable`                                                            | `string` |  **no**  | The latest minor version of the version being built                     |
+| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | The latest patch version of the version being built                     |
+| **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook. |
 
 <br /><br />
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ and then set up your environment in typedoc.json
 | :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | --------------------------------------------------------------------------------------------- |
 | **_stable_**      | The minor version that you would like to be marked as `stable`                                                            | `string` |  **no**  | The latest minor version of the version being built                                           |
 | **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | The latest patch version of the version being built                                           |
-| **_homeUrl_**     | The url to the base folder where you will host your documentation set                                                     | `string` |  **no**  | will try to determine the GitHUB package url from package.json and convert it to gh-page url. |
 | **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook.                       |
 
 <br /><br />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "typedoc-plugin-versions",
-			"version": "0.0.5",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.0.5",
+	"version": "0.1.0",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
 	"main": "src/index",
 	"scripts": {

--- a/src/etc/utils.ts
+++ b/src/etc/utils.ts
@@ -18,21 +18,6 @@ const packagePath = path.join(process.cwd(), 'package.json');
 const pack = fs.readJSONSync(packagePath);
 
 /**
- * Attempts to find the github repository location url and parse it into a github pages url.
- * @param repository
- * @returns The github pages url or a dummy url
- */
-export function getGhPageUrl(repository: { url } = pack.repository) {
-	if (!repository || !repository.url) {
-		return 'http://localhost:5500/docs';
-	}
-	const splitUrl = repository.url.split('/');
-	const gitName = splitUrl[3];
-	const repoName = splitUrl[4].split('.')[0];
-	return `https://${gitName}.github.io/${repoName}`;
-}
-
-/**
  * Gets the package version defined in package.json
  * @param version
  * @returns The package version
@@ -145,20 +130,6 @@ export const DOC_VERSIONS = [
 ];
 `;
 	return js;
-}
-
-/**
- * Creates a string (of HTML) that re-directs to the 'stable' documentation url.
- * @param docRoot The root url of the documentation site
- * @returns a string of valid HTML
- */
-export function makeIndex(docRoot: string) {
-	const baseUrl = new URL(docRoot);
-	const newUrl = new URL(
-		path.join(baseUrl.pathname, 'stable'),
-		baseUrl.origin
-	);
-	return `<meta http-equiv="refresh" content="0; url=${newUrl.href}"/>`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,10 @@ export function load(app: Application) {
 		const jsVersionKeys = vUtils.makeJsKeys(semGroups);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
-		fs.writeFileSync(path.join(rootPath, 'index.html'), '<meta http-equiv="refresh" content="0; url=stable"/>');
+		fs.writeFileSync(
+			path.join(rootPath, 'index.html'),
+			'<meta http-equiv="refresh" content="0; url=stable"/>'
+		);
 	});
 
 	return vOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ export function load(app: Application) {
 		defaultValue: {
 			stable: vUtils.getMinorVersion(),
 			dev: vUtils.getSemanticVersion(),
-			homeUrl: vUtils.getGhPageUrl(),
 			domLocation: 'false',
 		} as versionsOptions,
 	});
@@ -65,8 +64,7 @@ export function load(app: Application) {
 		const jsVersionKeys = vUtils.makeJsKeys(semGroups);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
-		const htmlIndex = vUtils.makeIndex(vOptions.homeUrl);
-		fs.writeFileSync(path.join(rootPath, 'index.html'), htmlIndex);
+		fs.writeFileSync(path.join(rootPath, 'index.html'), '<meta http-equiv="refresh" content="0; url=stable"/>');
 	});
 
 	return vOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,11 +19,6 @@ export interface versionsOptions {
 	 */
 	dev?: patchVersion;
 	/**
-	 * The url to the base folder where you will host your documentation set
-	 * Default: will try to determine the GitHUB package url from package.json and convert it to gh-page url.
-	 */
-	homeUrl?: string;
-	/**
 	 * A custom DOM location to render the HTML `select` dropdown corresponding to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.
 	 */

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,7 +5,6 @@ import * as vUtils from '../src/etc/utils';
 import { minorVerRegex, verRegex } from '../src/etc/utils';
 import {
 	docsPath,
-	htmlRedirect,
 	jsKeys,
 	stubOptionKeys,
 	stubPathKeys,
@@ -26,24 +25,6 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 		);
 	});
 
-	describe('parsing for documentation root url', function () {
-		it('parses git url to gh-page url', function () {
-			assert.equal(
-				vUtils.getGhPageUrl({
-					url: 'git+https://github.com/username/repository.git',
-				}),
-				'https://username.github.io/repository',
-				'did not parse gh-pages url correctly'
-			);
-		});
-		it('provides a default document url if none given', function () {
-			assert.equal(
-				vUtils.getGhPageUrl({ url: null }),
-				'http://localhost:5500/docs',
-				'did not provide a default document url'
-			);
-		});
-	});
 	describe('retrieving package version', function () {
 		it('retrieves patch value from package.json', function () {
 			assert.match(
@@ -102,14 +83,6 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				vUtils.makeJsKeys(semGroups),
 				jsKeys,
 				'did not create a valid js string'
-			);
-		});
-		it('creates a redirect string for index.html', function () {
-			const url = vUtils.getGhPageUrl({ url: null });
-			assert.equal(
-				vUtils.makeIndex(url),
-				htmlRedirect,
-				'did not create a valid htm redirect string'
 			);
 		});
 	});

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -21,6 +21,3 @@ export const DOC_VERSIONS = [
 	'dev'
 ];
 `;
-
-export const htmlRedirect =
-	'<meta http-equiv="refresh" content="0; url=http://localhost:5500/docs/stable"/>';


### PR DESCRIPTION
## Changes in this pull request

Dropped support for the `homeUrl` option.

### Reasoning
This option is solely used for redirecting from the `docs/index.html` page to the `docs/stable` directory. Currently, the plugin achieves this by way of an absolute URL, i.e. it requires to know where the docs will live in production and joins `/stable` onto the end of that path.
If the option was not provided, it will attempt to guess at it by scouring your `package.json` and converting your listed git repository into a github pages URL.
This would then be used to produce an `index.html` with the following (example) content:

```html
<meta http-equiv="refresh" content="0; url=https://citkane.github.io/typedoc-plugin-versions/stable"/>
```

However, the same task can be accomplished by simply always outputting `index.html` as follows:
```html
<meta http-equiv="refresh" content="0; url=stable"/>
```
As the `index.html` always lives at the root of your docs, it can simply point to the `stable` directory via a relative path as above, i.e.:
- If `index.html` is located at `https://citkane.github.io/typedoc-plugin-versions`, it will redirect to `https://citkane.github.io/typedoc-plugin-versions/stable`
- If `index.html` is located at `http://localhost:5501/docs`, it will redirect to `http://localhost:5501/docs/stable`

This has the added benefit of eliminating the possibility of [accidentally committing a localhost docs path to your main branch](https://github.com/citkane/typedoc-plugin-versions/issues/1#issuecomment-1224230676) while testing locally!

### Implementation details
- `homeUrl` removed from options
- Removed utility functions from `etc/utils.ts` as they no longer serve any purpose:
  - `getGhPageUrl`
  - `makeIndex`
- Updated tests to reflect changes
- Updated `README.md` to reflect the changes
- Version bump to 0.1.0 to indicate a breaking change (due to the fact that two previously exported functions have been removed from the API)

I have done some testing, but due to the nature of this repository requiring Linux for running builds and therefore being unsuitable for local testing in my dev environment via `npm link`, I would advise thorough testing in your own dev environment.