### PR TITLE
Use `semver` package for handling semantic versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "typedoc-plugin-versions",
-			"version": "0.1.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
-				"fs-extra": "^10.1.0"
+				"fs-extra": "^10.1.0",
+				"semver": "^7.3.7"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.1",
@@ -17,6 +18,7 @@
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^18.6.2",
 				"@types/prettier": "^2.7.0",
+				"@types/semver": "^7.3.12",
 				"@typescript-eslint/eslint-plugin": "^5.34.0",
 				"@typescript-eslint/parser": "^5.34.0",
 				"chai": "^4.3.6",
@@ -102,6 +104,15 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@babel/generator": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
@@ -146,6 +157,15 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
@@ -846,6 +866,12 @@
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.3.12",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+			"integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+			"dev": true
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
@@ -877,21 +903,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -1002,21 +1013,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -2490,6 +2486,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/istanbul-lib-processinfo": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
@@ -2615,9 +2620,9 @@
 			}
 		},
 		"node_modules/jsonc-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
 		"node_modules/jsonfile": {
@@ -2712,7 +2717,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -2741,6 +2745,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2748,9 +2761,9 @@
 			"dev": true
 		},
 		"node_modules/marked": {
-			"version": "4.0.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-			"integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -3486,12 +3499,17 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/serialize-javascript": {
@@ -3531,14 +3549,14 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
 			"dev": true,
 			"dependencies": {
 				"jsonc-parser": "^3.0.0",
 				"vscode-oniguruma": "^1.6.1",
-				"vscode-textmate": "5.2.0"
+				"vscode-textmate": "^6.0.0"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -3856,15 +3874,15 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.23.10",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
-			"integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+			"version": "0.23.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+			"integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
 			"dev": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
-				"marked": "^4.0.18",
+				"marked": "^4.0.19",
 				"minimatch": "^5.1.0",
-				"shiki": "^0.10.1"
+				"shiki": "^0.11.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -3873,7 +3891,7 @@
 				"node": ">= 14.14"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x"
+				"typescript": "4.6.x || 4.7.x || 4.8.x"
 			}
 		},
 		"node_modules/typedoc/node_modules/minimatch": {
@@ -3972,9 +3990,9 @@
 			"dev": true
 		},
 		"node_modules/vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
 			"dev": true
 		},
 		"node_modules/which": {
@@ -4060,8 +4078,7 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
@@ -4198,6 +4215,14 @@
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.1",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
@@ -4234,6 +4259,14 @@
 				"@babel/helper-validator-option": "^7.18.6",
 				"browserslist": "^4.20.2",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-environment-visitor": {
@@ -4805,6 +4838,12 @@
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.3.12",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+			"integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+			"dev": true
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
@@ -4820,17 +4859,6 @@
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/parser": {
@@ -4885,17 +4913,6 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/utils": {
@@ -5971,6 +5988,14 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-lib-processinfo": {
@@ -6070,9 +6095,9 @@
 			"dev": true
 		},
 		"jsonc-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -6150,7 +6175,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -6168,6 +6192,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"make-error": {
@@ -6177,9 +6209,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "4.0.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-			"integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true
 		},
 		"merge2": {
@@ -6711,10 +6743,12 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
@@ -6747,14 +6781,14 @@
 			"dev": true
 		},
 		"shiki": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
 			"dev": true,
 			"requires": {
 				"jsonc-parser": "^3.0.0",
 				"vscode-oniguruma": "^1.6.1",
-				"vscode-textmate": "5.2.0"
+				"vscode-textmate": "^6.0.0"
 			}
 		},
 		"signal-exit": {
@@ -6989,15 +7023,15 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.23.10",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
-			"integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+			"version": "0.23.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+			"integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
 			"dev": true,
 			"requires": {
 				"lunr": "^2.3.9",
-				"marked": "^4.0.18",
+				"marked": "^4.0.19",
 				"minimatch": "^5.1.0",
-				"shiki": "^0.10.1"
+				"shiki": "^0.11.1"
 			},
 			"dependencies": {
 				"minimatch": {
@@ -7066,9 +7100,9 @@
 			"dev": true
 		},
 		"vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
 			"dev": true
 		},
 		"which": {
@@ -7136,8 +7170,7 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 	"author": "Michael Jonker",
 	"license": "MIT",
 	"dependencies": {
-		"fs-extra": "^10.1.0"
+		"fs-extra": "^10.1.0",
+		"semver": "^7.3.7"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.1",
@@ -36,6 +37,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.6.2",
 		"@types/prettier": "^2.7.0",
+		"@types/semver": "^7.3.12",
 		"@typescript-eslint/eslint-plugin": "^5.34.0",
 		"@typescript-eslint/parser": "^5.34.0",
 		"chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
 	"main": "src/index",
 	"scripts": {
@@ -26,6 +26,9 @@
 		"versioning"
 	],
 	"author": "Michael Jonker",
+	"contributors": [
+		"Tobey Blaber (https://github.com/toebeann)"
+	],
 	"license": "MIT",
 	"dependencies": {
 		"fs-extra": "^10.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,13 +55,13 @@ export function load(app: Application) {
 		vUtils.handleJeckyll(rootPath, targetPath);
 
 		const directories = vUtils.getPackageDirectories(rootPath);
-		const semGroups = vUtils.getSemGroups(directories);
+		const semVers = vUtils.getSemVers(directories);
 
-		vUtils.makeStableLink(rootPath, semGroups, vOptions.stable);
-		vUtils.makeDevLink(rootPath, semGroups, vOptions.dev);
-		vUtils.makeMinorVersionLinks(semGroups, rootPath);
+		vUtils.makeStableLink(rootPath, semVers, vOptions.stable);
+		vUtils.makeDevLink(rootPath, vOptions.dev);
+		vUtils.makeMinorVersionLinks(semVers, rootPath);
 
-		const jsVersionKeys = vUtils.makeJsKeys(semGroups);
+		const jsVersionKeys = vUtils.makeJsKeys(semVers);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
 		fs.writeFileSync(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,22 +12,19 @@ export interface versionsOptions {
 	 * The minor version that you would like to be marked as `stable`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	stable?: minorVersion;
+	stable?: version;
 	/**
 	 * The version that you would like to be marked as `dev`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	dev?: patchVersion;
+	dev?: version;
 	/**
 	 * A custom DOM location to render the HTML `select` dropdown corresponding to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.
 	 */
 	domLocation?: validLocation | 'false';
 }
-export type minorVersion = `${string | number}.${number}`;
-export type patchVersion = `${minorVersion}.${number}`;
-export type version = minorVersion | patchVersion;
-export type semanticGroups = { [key: string]: { [key: string]: number } };
+export type version = `v${string}`;
 
 /**
  * valid placement overrides for the select, corresponds to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -31,8 +31,14 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 			assert.match(
 				vUtils.getSemanticVersion(),
 				verRegex,
-				'did not provided a correctly formatted patch version'
+				'did not provide a correctly formatted patch version'
 			);
+		});
+		it('throws error if version not defined', function () {
+			assert.throws(() => {
+				// @ts-expect-error: Intentionally passing a falsy value to test the error condition.
+				vUtils.getSemanticVersion(null);
+			}, 'Package version was not found');
 		});
 		it('retrieves minor value from package.json', function () {
 			assert.match(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -63,7 +63,8 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				vUtils.getSemVers(directories),
 				['0.10.1', '0.2.3', '0.1.1', '0.0.0'].map((x) =>
 					semver.parse(x, true)
-				)
+				),
+				'did not return a correctly formatted SemVer[] array'
 			);
 		});
 	});

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -3,8 +3,8 @@ import { getSemanticVersion } from '../../src/etc/utils';
 
 export const stubsPath = __dirname;
 export const docsPath = path.join(stubsPath, 'docs');
-export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1'];
-export const stubSemanticLinks = ['v0.0', 'v0.1'];
+export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1', 'v0.2.3', 'v0.10.1'];
+export const stubSemanticLinks = ['v0.0', 'v0.1', 'v0.2', 'v0.10'];
 export const stubOptionKeys = ['stable', 'dev', 'domLocation'];
 export const stubPathKeys = ['rootPath', 'targetPath'];
 export const stubRootPath =
@@ -17,6 +17,8 @@ export const jsKeys = `
 
 export const DOC_VERSIONS = [
 	'stable',
+	'v0.10',
+	'v0.2',
 	'v0.1',
 	'v0.0',
 	'dev'


### PR DESCRIPTION
## Changes in this PR
- Fixes #11 
- Refactored all functions that work with semantic versioning to make use of [`semver`](https://www.npmjs.com/package/semver) - the package [used by `npm` for working with semantic versioning](https://www.npmjs.com/package/npm?activeTab=dependencies)

### Reasoning
[On one of my own packages](https://procedure-rpc.github.io/procedure.js), I found that typedoc-plugin-versions was incorrectly sorting version numbers in the dropdown version selector:
![image](https://user-images.githubusercontent.com/45315526/188323873-dd7264ed-628d-4655-b8a7-5b53c39cf1c1.png)

This appears to be due to the fact that you are using a basic alphanumeric reverse sorting operation, which is insufficient. As such, I determined the only way to rectify this would be to correctly implement semver sorting, and the most effective way to do this would be to use the same package that npm itself uses when it comes to handling semantic versioning.

With this change, after some testing, I can get the following output, which shows the versions correctly sorted as expected:
![image](https://user-images.githubusercontent.com/45315526/188323987-c11a2b19-d33a-4476-beea-51e2f4fd0cb8.png)

I reasoned that it is best to ensure that anywhere the package touches semantic versioning that it does so in a consistent manner that is in line with the spec. As such, I refactored every function that touches semantic versioning to use the [`semver`](https://www.npmjs.com/package/semver) package.

Additionally, upgrading semver logic to rely on the [`semver`](https://www.npmjs.com/package/semver) package makes it easy to handle more advanced logical operations, e.g:
 - #10 

### Implementation details
- Added a dependency on [`semver`](https://www.npmjs.com/package/semver) 
- Refactored functions that work with semantic versioning to make use of [`semver`](https://www.npmjs.com/package/semver)
- Simplified some logic
- Dropped some now-redundant type exports
- Added more versions in the stubs to test version sorting
- Updated tests as necessary
- Bumped to version `0.2.0` as the exports have been changed
- Added myself as a `contributor` in package.json