### PR TITLE
Bump to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ and then set up your environment in typedoc.json
 
 | Key               | Value Information                                                                                                         | Type     | Required | Default                                                                 |
 | :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ----------------------------------------------------------------------- |
-| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | Automatically inferred based on current version and build history.      |
-| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | Automatically inferred based on current version and build history.      |
+| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history.      |
+| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history.      |
 | **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook. |
 
 <br /><br />

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ and then set up your environment in typedoc.json
 
 | Key               | Value Information                                                                                                         | Type     | Required | Default                                                                 |
 | :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ----------------------------------------------------------------------- |
-| **_stable_**      | The minor version that you would like to be marked as `stable`                                                            | `string` |  **no**  | The latest minor version of the version being built                     |
-| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | The latest patch version of the version being built                     |
+| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | Automatically inferred based on current version and build history.      |
+| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | Automatically inferred based on current version and build history.      |
 | **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook. |
 
 <br /><br />

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ and then set up your environment in typedoc.json
 
 ## Options
 
-| Key               | Value Information                                                                                                         | Type     | Required | Default                                                                 |
-| :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ----------------------------------------------------------------------- |
-| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history.      |
-| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history.      |
-| **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook. |
+| Key               | Value Information                                                                                                         | Type     | Required | Default                                                                                                                                                                              |
+| :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history. |
+| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history. |
+| **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook.                                                                                                              |
 
 <br /><br />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "typedoc-plugin-versions",
-			"version": "0.1.1",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "typedoc-plugin-versions",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
-				"fs-extra": "^10.1.0"
+				"fs-extra": "^10.1.0",
+				"semver": "^7.3.7"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.1",
@@ -17,6 +18,7 @@
 				"@types/mocha": "^9.1.1",
 				"@types/node": "^18.6.2",
 				"@types/prettier": "^2.7.0",
+				"@types/semver": "^7.3.12",
 				"@typescript-eslint/eslint-plugin": "^5.34.0",
 				"@typescript-eslint/parser": "^5.34.0",
 				"chai": "^4.3.6",
@@ -102,6 +104,15 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/@babel/generator": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
@@ -146,6 +157,15 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
@@ -846,6 +866,12 @@
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.3.12",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+			"integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+			"dev": true
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
@@ -877,21 +903,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -1002,21 +1013,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -2490,6 +2486,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/istanbul-lib-instrument/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/istanbul-lib-processinfo": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
@@ -2615,9 +2620,9 @@
 			}
 		},
 		"node_modules/jsonc-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
 		"node_modules/jsonfile": {
@@ -2712,7 +2717,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -2741,6 +2745,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2748,9 +2761,9 @@
 			"dev": true
 		},
 		"node_modules/marked": {
-			"version": "4.0.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-			"integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -3486,12 +3499,17 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/serialize-javascript": {
@@ -3531,14 +3549,14 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
 			"dev": true,
 			"dependencies": {
 				"jsonc-parser": "^3.0.0",
 				"vscode-oniguruma": "^1.6.1",
-				"vscode-textmate": "5.2.0"
+				"vscode-textmate": "^6.0.0"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -3856,15 +3874,15 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.23.10",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
-			"integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+			"version": "0.23.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+			"integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
 			"dev": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
-				"marked": "^4.0.18",
+				"marked": "^4.0.19",
 				"minimatch": "^5.1.0",
-				"shiki": "^0.10.1"
+				"shiki": "^0.11.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -3873,7 +3891,7 @@
 				"node": ">= 14.14"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x"
+				"typescript": "4.6.x || 4.7.x || 4.8.x"
 			}
 		},
 		"node_modules/typedoc/node_modules/minimatch": {
@@ -3972,9 +3990,9 @@
 			"dev": true
 		},
 		"node_modules/vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
 			"dev": true
 		},
 		"node_modules/which": {
@@ -4060,8 +4078,7 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
@@ -4198,6 +4215,14 @@
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.2.1",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
@@ -4234,6 +4259,14 @@
 				"@babel/helper-validator-option": "^7.18.6",
 				"browserslist": "^4.20.2",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-environment-visitor": {
@@ -4805,6 +4838,12 @@
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.3.12",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+			"integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+			"dev": true
+		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
@@ -4820,17 +4859,6 @@
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/parser": {
@@ -4885,17 +4913,6 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@typescript-eslint/utils": {
@@ -5971,6 +5988,14 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-lib-processinfo": {
@@ -6070,9 +6095,9 @@
 			"dev": true
 		},
 		"jsonc-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-			"integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -6150,7 +6175,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -6168,6 +6192,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"make-error": {
@@ -6177,9 +6209,9 @@
 			"dev": true
 		},
 		"marked": {
-			"version": "4.0.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-			"integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"dev": true
 		},
 		"merge2": {
@@ -6711,10 +6743,12 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",
@@ -6747,14 +6781,14 @@
 			"dev": true
 		},
 		"shiki": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-			"integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+			"integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
 			"dev": true,
 			"requires": {
 				"jsonc-parser": "^3.0.0",
 				"vscode-oniguruma": "^1.6.1",
-				"vscode-textmate": "5.2.0"
+				"vscode-textmate": "^6.0.0"
 			}
 		},
 		"signal-exit": {
@@ -6989,15 +7023,15 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.23.10",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
-			"integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+			"version": "0.23.14",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
+			"integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
 			"dev": true,
 			"requires": {
 				"lunr": "^2.3.9",
-				"marked": "^4.0.18",
+				"marked": "^4.0.19",
 				"minimatch": "^5.1.0",
-				"shiki": "^0.10.1"
+				"shiki": "^0.11.1"
 			},
 			"dependencies": {
 				"minimatch": {
@@ -7066,9 +7100,9 @@
 			"dev": true
 		},
 		"vscode-textmate": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+			"integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
 			"dev": true
 		},
 		"which": {
@@ -7136,8 +7170,7 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 	"author": "Michael Jonker",
 	"license": "MIT",
 	"dependencies": {
-		"fs-extra": "^10.1.0"
+		"fs-extra": "^10.1.0",
+		"semver": "^7.3.7"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.1",
@@ -36,6 +37,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.6.2",
 		"@types/prettier": "^2.7.0",
+		"@types/semver": "^7.3.12",
 		"@typescript-eslint/eslint-plugin": "^5.34.0",
 		"@typescript-eslint/parser": "^5.34.0",
 		"chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
 	"main": "src/index",
 	"scripts": {
@@ -26,6 +26,9 @@
 		"versioning"
 	],
 	"author": "Michael Jonker",
+	"contributors": [
+		"Tobey Blaber (https://github.com/toebeann)"
+	],
 	"license": "MIT",
 	"dependencies": {
 		"fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
 		],
 		"reporter": [
 			"clover",
-			"text"
+			"text",
+			"html"
 		],
 		"all": true,
 		"report-dir": "./test/coverage",

--- a/src/assets/versionsMenu.js
+++ b/src/assets/versionsMenu.js
@@ -10,10 +10,12 @@ DOC_VERSIONS.forEach((version) => {
 });
 
 const locationSplit = location.pathname.split('/');
-const thisVersion = locationSplit.find(
-	(path) => DOC_VERSIONS.indexOf(path) > -1
+const thisVersion = locationSplit.find((path) =>
+	['stable', 'dev', ...DOC_VERSIONS].includes(path)
 );
-select.value = thisVersion;
+select.value = DOC_VERSIONS.includes(thisVersion)
+	? thisVersion
+	: DOC_VERSIONS[0];
 select.onchange = () => {
 	const newPaths = window.location.pathname.replace(
 		`/${thisVersion}/`,

--- a/src/etc/utils.ts
+++ b/src/etc/utils.ts
@@ -6,7 +6,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import semver, { SemVer } from 'semver';
+import semver from 'semver';
 import { version, semanticAlias, versionsOptions } from '../types';
 import { Application, Logger, TypeDocReader } from 'typedoc';
 const packagePath = path.join(process.cwd(), 'package.json');
@@ -19,18 +19,20 @@ const pack = fs.readJSONSync(packagePath);
  * @todo grab potential labels from the version and provide them as further pegs in the menu.
  */
 export function getSemanticVersion(version: string = pack.version): version {
-	!version &&
-		(() => {
-			throw new Error('Package version was not found');
-		})();
+	if (!version) {
+		throw new Error('Package version was not found');
+	}
 
 	const semVer = semver.coerce(version, { loose: true });
-
 	if (!semVer) {
 		throw new Error(`version is not semantically formatted: ${version}`);
 	}
 
-	return `v${semVer.version}`;
+	// ensure prerelease info remains appended
+	const prerelease = semver.prerelease(version, true);
+	return prerelease
+		? `v${semVer.version}-${semver.prerelease(version, true).join('.')}`
+		: `v${semVer.version}`;
 }
 
 /**
@@ -39,7 +41,6 @@ export function getSemanticVersion(version: string = pack.version): version {
  */
 export function getMinorVersion(version?: string): version {
 	version = getSemanticVersion(version);
-
 	const { major, minor } = semver.coerce(version, { loose: true });
 	return `v${major}.${minor}`;
 }
@@ -57,96 +58,76 @@ export function getPackageDirectories(docRoot: string): string[] {
 }
 
 /**
- * Creates groups of semantic versions with the latest patch version identified
- * @param directories an array of semantically named directories to be processed
- * @returns
+ * Gets a list of semantic versions from a list of directories, sorted in descending order.
+ * @param directories An array of semantically named directories to be processed
+ * @returns An array of {@link version versions}, sorted in descending order.
  */
-export function getSemVers(directories: string[]): SemVer[] {
+export function getVersions(directories: string[]): version[] {
 	return directories
-		.map((dir) => semver.coerce(dir, { loose: true })) // parse directory names to SemVer instances (convert to (SemVer | null)[])
-		.filter((v) => v instanceof SemVer) // discard nulls (convert to SemVer[])
-		.sort(semver.rcompare) // sort in descending order
-		.filter(
-			// only include highest patch number per major.minor version & ensure each entry is unique
-			(value, index, self) =>
-				self.indexOf(
-					self.find((x) =>
-						semver.satisfies(x, `${value.major}.${value.minor}.x`)
-					)
-				) === index && self.indexOf(value) === index
-		);
+		.filter((dir) => semver.coerce(dir, { loose: true }))
+		.map((dir) => getSemanticVersion(dir))
+		.sort(semver.rcompare);
 }
 
 /**
  * Creates a string (of javascript) defining an array of all the versions to be included in the frontend select
- * @param semVers
+ * @param versions
+ * @param docRoot
+ * @param [stable='auto'] The version set in the options for the 'dev' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
  * @returns
  */
-export function makeJsKeys(semVers: SemVer[]): string {
-	let js = `
-"use strict"
-
-export const DOC_VERSIONS = [
-	'stable',
-`;
-	for (const version of semVers.map((v) => getMinorVersion(v.version))) {
-		js += `	'${version}',\n`;
+export function makeJsKeys(
+	versions: version[],
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): string {
+	const stableVer = getSymlinkVersion('stable', docRoot);
+	const devVer = getSymlinkVersion('dev', docRoot);
+	const alias = getVersionAlias(stableVer, stable, dev);
+	const keys = [
+		alias, // add initial key (stable or dev)
+		...versions // add the major.minor versions
+			.map((v) => getMinorVersion(v))
+			.filter((v, i, s) => s.indexOf(v) === i),
+	];
+	if (
+		alias !== 'dev' && // initial key is not dev
+		((dev !== 'auto' && devVer === getSemanticVersion(dev)) || // explicit dev version
+			semver.lt(stableVer, devVer, true)) // dev version newer than stable
+	) {
+		keys.push('dev');
 	}
-	js += `	'dev'
-];
-`;
-	return js;
+	// finally, create the js string
+	const lines = [
+		'"use strict"',
+		'export const DOC_VERSIONS = [',
+		...keys.map((v) => `	'${v}',`),
+		'];',
+	];
+	return lines.join('\n').concat('\n');
 }
 
 /**
- * Creates a symlink for the stable release
- * @param docRoot
- * @param semVers
- * @param pegVersion
- * @param name
- */
-export function makeStableLink(
-	docRoot: string,
-	semVers: SemVer[],
-	pegVersion: version,
-	name: semanticAlias = 'stable'
-): void {
-	pegVersion = getMinorVersion(pegVersion);
-
-	const version = semver.coerce(pegVersion, { loose: true });
-	const srcVer = semVers.find((v) =>
-		semver.satisfies(v, `${version.major}.${version.minor}.x`)
-	);
-
-	if (!srcVer) {
-		throw new Error(`Document directory does not exist: ${pegVersion}`);
-	}
-
-	const stableSource = path.join(docRoot, getSemanticVersion(srcVer.version));
-	const stableTarget = path.join(docRoot, name);
-	fs.existsSync(stableTarget) && fs.unlinkSync(stableTarget);
-	fs.ensureSymlinkSync(stableSource, stableTarget, 'junction');
-}
-
-/**
- * Creates a symlink for the dev release
+ * Creates a symlink for an alias
+ * @param alias
  * @param docRoot
  * @param pegVersion
- * @param name
  */
-export function makeDevLink(
+export function makeAliasLink(
+	alias: semanticAlias,
 	docRoot: string,
-	pegVersion: version,
-	name: semanticAlias = 'dev'
+	pegVersion: version
 ): void {
 	pegVersion = getSemanticVersion(pegVersion);
-	const devSource = path.join(docRoot, pegVersion);
+	const stableSource = path.join(docRoot, pegVersion);
 
-	if (!fs.existsSync(devSource))
+	if (!fs.existsSync(stableSource))
 		throw new Error(`Document directory does not exist: ${pegVersion}`);
-	const devTarget = path.join(docRoot, name);
-	fs.existsSync(devTarget) && fs.unlinkSync(devTarget);
-	fs.ensureSymlinkSync(devSource, devTarget, 'junction');
+	const stableTarget = path.join(docRoot, alias);
+	fs.existsSync(stableTarget) && fs.unlinkSync(stableTarget);
+	fs.ensureSymlinkSync(stableSource, stableTarget, 'junction');
 }
 
 /**
@@ -155,12 +136,40 @@ export function makeDevLink(
  * @param docRoot
  */
 export function makeMinorVersionLinks(
-	semVers: SemVer[],
-	docRoot: string
+	versions: version[],
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
 ): void {
-	for (const v of semVers) {
-		const target = path.join(docRoot, getMinorVersion(v.version));
-		const src = path.join(docRoot, getSemanticVersion(v.version));
+	for (const version of versions
+		// get highest patch per version
+		.map((version) => {
+			// prefer stable where available
+			const highestStablePatch = versions.find(
+				(v) =>
+					getVersionAlias(v, stable, dev) === 'stable' &&
+					semver.satisfies(
+						v,
+						`${semver.major(version)}.${semver.minor(version)}.x`,
+						{ includePrerelease: true }
+					)
+			);
+			// fallback to highest patch
+			return (
+				highestStablePatch ??
+				versions.find((v) =>
+					semver.satisfies(
+						v,
+						`${semver.major(version)}.${semver.minor(version)}.x`,
+						{ includePrerelease: true }
+					)
+				)
+			);
+		})
+		// filter to unique values
+		.filter((v, i, s) => s.indexOf(v) === i)) {
+		const target = path.join(docRoot, getMinorVersion(version));
+		const src = path.join(docRoot, version);
 		fs.existsSync(target) && fs.unlinkSync(target);
 		fs.ensureSymlinkSync(src, target, 'junction');
 	}
@@ -185,7 +194,7 @@ export function getVersionsOptions(app: Application): versionsOptions {
  * @param version
  * @returns the paths
  */
-export function getPaths(app, version?: version) {
+export function getPaths(app: Application, version?: version) {
 	const defaultRootPath = path.join(process.cwd(), 'docs');
 	const rootPath = app.options.getValue('out') || defaultRootPath;
 	return {
@@ -217,6 +226,94 @@ export function handleAssets(targetPath: string, srcDir: string = __dirname) {
 		sourceAsset,
 		path.join(targetPath, 'assets/versionsMenu.js')
 	);
+}
+
+/**
+ * Gets the {@link semanticAlias alias} of the given version, e.g. 'stable' or 'dev'.
+ * @remarks
+ * Versions {@link https://semver.org/#spec-item-4 lower than 1.0.0} or
+ * {@link https://semver.org/#spec-item-9 with a pre-release label} (e.g. 1.0.0-alpha.1)
+ * will be considered 'dev'. All other versions will be considered 'stable'.
+ * @param [version] Defaults to the version from `package.json`
+ * @param [stable='auto'] The version set in the typedoc options for the 'stable' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
+ * @returns The {@link semanticAlias alias} of the given version.
+ */
+export function getVersionAlias(
+	version?: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): semanticAlias {
+	version = getSemanticVersion(version);
+	if (stable !== 'auto' && version === getSemanticVersion(stable))
+		// version is marked as stable by user
+		return 'stable';
+	else if (dev !== 'auto' && version === getSemanticVersion(dev))
+		// version is marked as dev by user
+		return 'dev';
+	// semver.satisfies() automatically filters out prerelease versions by default
+	else return semver.satisfies(version, '>=1.0.0', true) ? 'stable' : 'dev';
+}
+
+/**
+ * Automatically parses the version number for a given {@link semanticAlias alias} based on
+ * typedoc options.
+ * @param alias The alias to parse, e.g. 'stable' or 'dev'.
+ * @param version The version set in the typedoc options for the alias.
+ * @param docRoot The path to the docs root.
+ * @param [stable='auto'] The version set in the typedoc options for the 'stable' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
+ * @returns The automatically parsed version number which should be used for the given alias.
+ */
+export function getAliasVersion(
+	alias: semanticAlias,
+	version: 'auto' | version,
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): version {
+	if (version !== 'auto') {
+		return getSemanticVersion(version); // user has explicitly specified a version, use it
+	}
+
+	// no explicit version set for alias, check if package version is a match
+	const packageVersion = getSemanticVersion();
+	if (getVersionAlias(packageVersion, stable, dev) === alias) {
+		// package version matches the alias
+		return packageVersion;
+	}
+
+	// package version is not a match, check symlink for alias
+	const symlinkVersion = getSymlinkVersion(alias, docRoot);
+	if (
+		symlinkVersion &&
+		getVersionAlias(symlinkVersion, stable, dev) === alias &&
+		(alias === 'stable' || semver.lt(packageVersion, symlinkVersion))
+	) {
+		// version symlinked alias is pointing to is a match
+		return symlinkVersion;
+	}
+
+	// no matches found, fall back to the package version
+	return packageVersion;
+}
+
+/**
+ * Gets the {@link version} a given symlink is pointing to.
+ * @param symlink The symlink path, relative to {@link docRoot}.
+ * @param docRoot The path to the docs root.
+ * @returns The version number parsed from the given symlink.
+ */
+export function getSymlinkVersion(symlink: string, docRoot: string): version {
+	const symlinkPath = path.join(docRoot, symlink);
+	if (
+		fs.existsSync(symlinkPath) &&
+		fs.lstatSync(symlinkPath).isSymbolicLink()
+	) {
+		// retrieve the version the symlink is pointing to
+		const targetPath = fs.readlinkSync(symlinkPath);
+		return getSemanticVersion(path.basename(targetPath));
+	}
 }
 
 /**

--- a/src/etc/utils.ts
+++ b/src/etc/utils.ts
@@ -132,9 +132,9 @@ export function refreshMetadataAlias(
 	} else {
 		const latest = getLatestVersion(alias, versions, stable, dev); // in auto mode, get latest version for the alias
 		if (
-			latest &&
-			(alias !== 'dev' ||
-				!getLatestVersion('stable', versions, stable, dev) ||
+			latest && // return undefined if latest version not set for alias
+			(alias !== 'dev' || // when alias is dev, only return latest dev if >= latest stable
+				!getLatestVersion('stable', versions, stable, dev) || // or there is no matching latest stable
 				semver.gte(
 					latest,
 					getLatestVersion('stable', versions, stable, dev),

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,13 +55,13 @@ export function load(app: Application) {
 		vUtils.handleJeckyll(rootPath, targetPath);
 
 		const directories = vUtils.getPackageDirectories(rootPath);
-		const semGroups = vUtils.getSemGroups(directories);
+		const semVers = vUtils.getSemVers(directories);
 
-		vUtils.makeStableLink(rootPath, semGroups, vOptions.stable);
-		vUtils.makeDevLink(rootPath, semGroups, vOptions.dev);
-		vUtils.makeMinorVersionLinks(semGroups, rootPath);
+		vUtils.makeStableLink(rootPath, semVers, vOptions.stable);
+		vUtils.makeDevLink(rootPath, vOptions.dev);
+		vUtils.makeMinorVersionLinks(semVers, rootPath);
 
-		const jsVersionKeys = vUtils.makeJsKeys(semGroups);
+		const jsVersionKeys = vUtils.makeJsKeys(semVers);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
 		fs.writeFileSync(

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ export function load(app: Application) {
 		name: 'versions',
 		type: ParameterType.Mixed,
 		defaultValue: {
-			stable: vUtils.getMinorVersion(),
-			dev: vUtils.getSemanticVersion(),
+			stable: 'auto',
+			dev: 'auto',
 			domLocation: 'false',
 		} as versionsOptions,
 	});
@@ -55,13 +55,32 @@ export function load(app: Application) {
 		vUtils.handleJeckyll(rootPath, targetPath);
 
 		const directories = vUtils.getPackageDirectories(rootPath);
-		const semVers = vUtils.getSemVers(directories);
+		const versions = vUtils.getVersions(directories);
+		const stable = vUtils.getAliasVersion(
+			'stable',
+			vOptions.stable,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
+		const dev = vUtils.getAliasVersion(
+			'dev',
+			vOptions.dev,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
 
-		vUtils.makeStableLink(rootPath, semVers, vOptions.stable);
-		vUtils.makeDevLink(rootPath, vOptions.dev);
-		vUtils.makeMinorVersionLinks(semVers, rootPath);
+		vUtils.makeAliasLink('stable', rootPath, stable);
+		vUtils.makeAliasLink('dev', rootPath, dev);
+		vUtils.makeMinorVersionLinks(versions, rootPath);
 
-		const jsVersionKeys = vUtils.makeJsKeys(semVers);
+		const jsVersionKeys = vUtils.makeJsKeys(
+			versions,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
 		fs.writeFileSync(

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,39 +54,30 @@ export function load(app: Application) {
 		vUtils.handleAssets(targetPath);
 		vUtils.handleJeckyll(rootPath, targetPath);
 
-		const directories = vUtils.getPackageDirectories(rootPath);
-		const versions = vUtils.getVersions(directories);
-		const stable = vUtils.getAliasVersion(
+		const metadata = vUtils.refreshMetadata(
+			vUtils.loadMetadata(rootPath),
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
+
+		vUtils.makeAliasLink(
 			'stable',
-			vOptions.stable,
 			rootPath,
-			vOptions.stable,
-			vOptions.dev
+			metadata.stable ?? metadata.dev
 		);
-		const dev = vUtils.getAliasVersion(
-			'dev',
-			vOptions.dev,
-			rootPath,
-			vOptions.stable,
-			vOptions.dev
-		);
+		vUtils.makeAliasLink('dev', rootPath, metadata.dev ?? metadata.stable);
+		vUtils.makeMinorVersionLinks(metadata.versions, rootPath);
 
-		vUtils.makeAliasLink('stable', rootPath, stable);
-		vUtils.makeAliasLink('dev', rootPath, dev);
-		vUtils.makeMinorVersionLinks(versions, rootPath);
-
-		const jsVersionKeys = vUtils.makeJsKeys(
-			versions,
-			rootPath,
-			vOptions.stable,
-			vOptions.dev
-		);
+		const jsVersionKeys = vUtils.makeJsKeys(metadata);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
 		fs.writeFileSync(
 			path.join(rootPath, 'index.html'),
 			'<meta http-equiv="refresh" content="0; url=stable"/>'
 		);
+
+		vUtils.saveMetadata(metadata, rootPath);
 	});
 
 	return vOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,9 @@ export function load(app: Application) {
 
 		fs.writeFileSync(
 			path.join(rootPath, 'index.html'),
-			'<meta http-equiv="refresh" content="0; url=stable"/>'
+			`<meta http-equiv="refresh" content="0; url=${
+				metadata.stable ? 'stable' : 'dev'
+			}"/>`
 		);
 
 		vUtils.saveMetadata(metadata, rootPath);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,12 @@ export interface versionsOptions {
 	 * The minor version that you would like to be marked as `stable`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	stable?: version;
+	stable?: version | 'auto';
 	/**
 	 * The version that you would like to be marked as `dev`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	dev?: version;
+	dev?: version | 'auto';
 	/**
 	 * A custom DOM location to render the HTML `select` dropdown corresponding to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,3 +37,9 @@ export type validLocation =
 	| 'navigation.begin'
 	| 'navigation.end';
 export type semanticAlias = 'stable' | 'dev';
+
+export type metadata = {
+	versions?: version[];
+	stable?: version;
+	dev?: version;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,22 +12,19 @@ export interface versionsOptions {
 	 * The minor version that you would like to be marked as `stable`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	stable?: minorVersion;
+	stable?: version;
 	/**
 	 * The version that you would like to be marked as `dev`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	dev?: patchVersion;
+	dev?: version;
 	/**
 	 * A custom DOM location to render the HTML `select` dropdown corresponding to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.
 	 */
 	domLocation?: validLocation | 'false';
 }
-export type minorVersion = `${string | number}.${number}`;
-export type patchVersion = `${minorVersion}.${number}`;
-export type version = minorVersion | patchVersion;
-export type semanticGroups = { [key: string]: { [key: string]: number } };
+export type version = `v${string}`;
 
 /**
  * valid placement overrides for the select, corresponds to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -66,10 +66,8 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
 			assert.deepEqual(
 				vUtils.getVersions(directories),
-				['0.10.1', '0.2.3', '0.1.1', '0.1.0', '0.0.0'].map((x) =>
-					vUtils.getSemanticVersion(x)
-				),
-				'did not return a correctly formatted SemVer[] array'
+				['v0.10.1', 'v0.2.3', 'v0.1.1', 'v0.1.0', 'v0.0.0'],
+				'did not return a correctly formatted version[] array'
 			);
 		});
 	});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import path from 'path';
 import fs from 'fs-extra';
-import semver from 'semver';
 import * as vUtils from '../src/etc/utils';
 import { minorVerRegex, verRegex } from '../src/etc/utils';
 import {
@@ -33,19 +32,19 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				verRegex,
 				'did not provided a correctly formatted patch version'
 			);
+			assert.equal(vUtils.getSemanticVersion('0.0.0'), 'v0.0.0');
+			assert.equal(vUtils.getSemanticVersion('0.2.0'), 'v0.2.0');
+			assert.equal(vUtils.getSemanticVersion('1.2.0'), 'v1.2.0');
+			assert.equal(
+				vUtils.getSemanticVersion('1.2.0-alpha.1'),
+				'v1.2.0-alpha.1'
+			);
 		});
 		it('retrieves minor value from package.json', function () {
 			assert.match(
 				vUtils.getMinorVersion(),
 				minorVerRegex,
 				'did not return a correctly formatted minor version'
-			);
-		});
-		it('discards patch from semantic version string', function () {
-			assert.match(
-				vUtils.getSemanticVersion('v11.10.09-label'),
-				verRegex,
-				'did not strip the label from version string'
 			);
 		});
 	});
@@ -57,12 +56,12 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				'did not retrieve all semanticly named directories'
 			);
 		});
-		it('lists semantic versions correctly with highest patch', function () {
+		it('lists semantic versions correctly', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
 			assert.deepEqual(
-				vUtils.getSemVers(directories),
-				['0.10.1', '0.2.3', '0.1.1', '0.0.0'].map((x) =>
-					semver.parse(x, true)
+				vUtils.getVersions(directories),
+				['0.10.1', '0.2.3', '0.1.1', '0.1.0', '0.0.0'].map((x) =>
+					vUtils.getSemanticVersion(x)
 				),
 				'did not return a correctly formatted SemVer[] array'
 			);
@@ -71,52 +70,74 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 	describe('creates browser assets', function () {
 		it('creates a valid js string from the sematic groups', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
+			const versions = vUtils.getVersions(directories);
 			assert.equal(
-				vUtils.makeJsKeys(semVers),
+				vUtils.makeJsKeys(versions, docsPath),
 				jsKeys,
 				'did not create a valid js string'
 			);
 		});
 	});
+	describe('infers stable and dev versions', function () {
+		it('correctly interprets versions as stable or dev', function () {
+			assert.equal(vUtils.getVersionAlias('v0.2.0'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v0.2.0-alpha.1'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v1.2.0-alpha.1'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v1.2.0'), 'stable');
+		});
+		it('infers stable version automatically', function () {
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'auto', docsPath),
+				vUtils.getSemanticVersion()
+			);
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'v1.0.0', docsPath),
+				'v1.0.0'
+			);
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'v1.0.0-alpha.1', docsPath),
+				'v1.0.0-alpha.1'
+			);
+		});
+		it('infers dev version automatically', function () {
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'auto', docsPath),
+				vUtils.getSemanticVersion()
+			);
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'v0.2.0', docsPath),
+				'v0.2.0'
+			);
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'v0.2.0-alpha.1', docsPath),
+				'v0.2.0-alpha.1'
+			);
+		});
+	});
 	describe('creates symlinks', function () {
 		it('creates a stable version symlink', function () {
-			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
-			vUtils.makeStableLink(docsPath, semVers, 'v0.1');
+			vUtils.makeAliasLink('stable', docsPath, 'v0.1');
 			const link = path.join(docsPath, 'stable');
 			assert.isTrue(
 				fs.existsSync(link),
 				'did not create a stable symlink'
 			);
-			assert.isTrue(
-				/test[/|\\]stubs[/|\\]docs[/|\\]v0.1.[1$|1/$|1\\$]/.test(
-					fs.readlinkSync(link)
-				),
-				'did not link the stable symlink correctly'
-			);
 			assert.throws(() => {
-				vUtils.makeStableLink(docsPath, semVers, 'v0.11');
+				vUtils.makeAliasLink('stable', docsPath, 'v0.11');
 			}, 'Document directory does not exist: v0.11');
 		});
 		it('creates a dev version symlink', function () {
-			vUtils.makeDevLink(docsPath, 'v0.1.0');
+			vUtils.makeAliasLink('dev', docsPath, 'v0.1.0');
 			const link = path.join(docsPath, 'dev');
 			assert.isTrue(fs.existsSync(link), 'did not create a dev symlink');
-			assert.isTrue(
-				/test[/|\\]stubs[/|\\]docs[/|\\]v0.1.[0$|0/$|0\\$]/.test(
-					fs.readlinkSync(link)
-				),
-				'did not link the dev symlink correctly'
-			);
 			assert.throws(() => {
-				vUtils.makeDevLink(docsPath, 'v0.11.1');
+				vUtils.makeAliasLink('dev', docsPath, 'v0.11.1');
 			}, 'Document directory does not exist: v0.11.1');
 		});
 		it('creates all minor version links', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
-			vUtils.makeMinorVersionLinks(semVers, docsPath);
+			const versions = vUtils.getVersions(directories);
+			vUtils.makeMinorVersionLinks(versions, docsPath);
 			stubSemanticLinks.forEach((link) => {
 				const linkPath = path.join(docsPath, link);
 				assert.isTrue(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -31,8 +31,14 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 			assert.match(
 				vUtils.getSemanticVersion(),
 				verRegex,
-				'did not provided a correctly formatted patch version'
+				'did not provide a correctly formatted patch version'
 			);
+		});
+		it('throws error if version not defined', function () {
+			assert.throws(() => {
+				// @ts-expect-error: Intentionally passing a falsy value to test the error condition.
+				vUtils.getSemanticVersion(null);
+			}, 'Package version was not found');
 		});
 		it('retrieves minor value from package.json', function () {
 			assert.match(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -63,7 +63,8 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				vUtils.getSemVers(directories),
 				['0.10.1', '0.2.3', '0.1.1', '0.0.0'].map((x) =>
 					semver.parse(x, true)
-				)
+				),
+				'did not return a correctly formatted SemVer[] array'
 			);
 		});
 	});

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -12,15 +12,12 @@ export const stubRootPath =
 export const stubTargetPath = (version) =>
 	path.join(stubRootPath, getSemanticVersion(version));
 
-export const jsKeys = `
-"use strict"
-
+export const jsKeys = `"use strict"
 export const DOC_VERSIONS = [
-	'stable',
+	'dev',
 	'v0.10',
 	'v0.2',
 	'v0.1',
 	'v0.0',
-	'dev'
 ];
 `;

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -3,8 +3,8 @@ import { getSemanticVersion } from '../../src/etc/utils';
 
 export const stubsPath = __dirname;
 export const docsPath = path.join(stubsPath, 'docs');
-export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1'];
-export const stubSemanticLinks = ['v0.0', 'v0.1'];
+export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1', 'v0.2.3', 'v0.10.1'];
+export const stubSemanticLinks = ['v0.0', 'v0.1', 'v0.2', 'v0.10'];
 export const stubOptionKeys = ['stable', 'dev', 'domLocation'];
 export const stubPathKeys = ['rootPath', 'targetPath'];
 export const stubRootPath =
@@ -17,6 +17,8 @@ export const jsKeys = `
 
 export const DOC_VERSIONS = [
 	'stable',
+	'v0.10',
+	'v0.2',
 	'v0.1',
 	'v0.0',
 	'dev'

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,8 +8,5 @@
 	"excludeExternals": true,
 	"logLevel": "Verbose",
 	"plugin": ["./dist"],
-	"includeVersion": true,
-	"versions": {
-		"stable": "0.1"
-	}
+	"includeVersion": true
 }


### PR DESCRIPTION
Version 0.2.0 changelog:
- Fixes sorting on the version dropdown select
- Introduces automatic version inference if not explicitly set in the user options