### PR TITLE
Fix: `typedoc-plugin-versions` not appearing in plugins listing on typedoc.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"plugin",
 		"typedoc-plugin",
 		"versions",
-		"versioning"
+		"versioning",
+		"typedocplugin"
 	],
 	"author": "Michael Jonker",
 	"contributors": [


### PR DESCRIPTION
## Changes in this pull request
- Adds the keyword `typedocplugin` to package.json

## Reasoning

Currently, this plugin does not appear on https://typedoc.org/guides/plugins/

From a brief peruse over how the typedoc website generates the list of plugins to display, I discovered that it [appears to be using the following search string via the npm website: `keywords:typedoc-plugin keywords:typedocplugin`](https://github.com/TypeStrong/typedoc-site/blob/fc333b73837423cc056040f151c1ad7c16b2ac58/scripts/plugins.ts#L2). The results of this search [can be viewed here](https://www.npmjs.com/search?q=keywords%3Atypedoc-plugin%20keywords%3Atypedocplugin), and this plugin is not among them.

The problem seems to stem from how npm handles multiple search terms - it is joining them by AND rather than OR, i.e. only displaying results which match all given search terms rather than matching any. [Merely changing the search to only include the search term `keywords:typedoc-plugin` displays this plugin in the results](https://www.npmjs.com/search?q=keywords%3Atypedoc-plugin). This means that for a package to appear in the search, it requires both keywords:
- `typedoc-plugin`
- `typedocplugin`

Presently, this plugin only lists the keyword `typedoc-plugin` in package.json, not both.

At some point in the future it might an idea to PR [typedoc-site](https://github.com/TypeStrong/typedoc-site) to run individual searches for each keyword and combines the results into a single list of plugins. In the meantime however, the simplest way to display this plugin on the list should be simply to add the missing `typedocplugin` keyword.