### PR TITLE
Bump to 0.2.1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 docs
 .nyc*
+/test/coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "typedoc-plugin-versions",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"fs-extra": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typedoc-plugin-versions",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
 	"main": "src/index",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"plugin",
 		"typedoc-plugin",
 		"versions",
-		"versioning"
+		"versioning",
+		"typedocplugin"
 	],
 	"author": "Michael Jonker",
 	"contributors": [

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -146,11 +146,7 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				vUtils.refreshMetadata(metadata, docsPath).dev,
 				'v0.10.1'
 			);
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
-			const currentVersion = require(path.join(
-				rootDir,
-				'package.json'
-			)).version;
+			const currentVersion = process.env.npm_package_version;
 			assert.equal(
 				vUtils.refreshMetadata(
 					metadata,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,7 +6,6 @@ import { minorVerRegex, verRegex } from '../src/etc/utils';
 import {
 	docsPath,
 	jsKeys,
-	rootDir,
 	stubOptionKeys,
 	stubPathKeys,
 	stubRootPath,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -6,6 +6,7 @@ import { minorVerRegex, verRegex } from '../src/etc/utils';
 import {
 	docsPath,
 	jsKeys,
+	rootDir,
 	stubOptionKeys,
 	stubPathKeys,
 	stubRootPath,
@@ -145,10 +146,19 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				vUtils.refreshMetadata(metadata, docsPath).dev,
 				'v0.10.1'
 			);
+			// eslint-disable-next-line @typescript-eslint/no-var-requires
+			const currentVersion = require(path.join(
+				rootDir,
+				'package.json'
+			)).version;
 			assert.equal(
-				vUtils.refreshMetadata(metadata, docsPath, undefined, '0.2.0')
-					.dev,
-				'v0.2.0'
+				vUtils.refreshMetadata(
+					metadata,
+					docsPath,
+					undefined,
+					currentVersion
+				).dev,
+				'v' + currentVersion
 			);
 			assert.equal(
 				// will fail when our package.json version > 0.10.1

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { getSemanticVersion } from '../../src/etc/utils';
 
-export const rootDir = path.join(__dirname, '../../');
 export const stubsPath = __dirname;
 export const docsPath = path.join(stubsPath, 'docs');
 export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1', 'v0.2.3', 'v0.10.1'];

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { getSemanticVersion } from '../../src/etc/utils';
 
+export const rootDir = path.join(__dirname, '../../');
 export const stubsPath = __dirname;
 export const docsPath = path.join(stubsPath, 'docs');
 export const stubVersions = ['v0.0.0', 'v0.1.0', 'v0.1.1', 'v0.2.3', 'v0.10.1'];


### PR DESCRIPTION
Adds the 'typedocplugin' npm tag for improved discoverability.
Fixes test to automatically allow for inference from latest package.json version.
