### PR TITLE
Add ending / to ensure the path-relative resources are referenced correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export function load(app: Application) {
 		fs.writeFileSync(
 			path.join(rootPath, 'index.html'),
 			`<meta http-equiv="refresh" content="0; url=${
-				metadata.stable ? 'stable' : 'dev'
+				metadata.stable ? 'stable/' : 'dev/'
 			}"/>`
 		);
 


### PR DESCRIPTION
Without this change, the path-relative resources (/assets/...) attempt to get loaded from the root path, which is not where they exist and so a 404 is returned.

This patch corrects the redirected location to ensure that it ends in `/` as then the path-relative resources will load from `/stable/assets` or `/dev/assets`, which is where they exist