### PR TITLE
Add custom root package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ and then set up your environment in typedoc.json
 | **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history. |
 | **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | [Automatically inferred](https://github.com/citkane/typedoc-plugin-versions/wiki/%22stable%22-and-%22dev%22-version-automatic-inference) based on current version and build history. |
 | **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook.                                                                                                              |
+| **rootFile**         | Optionally pass in the name of the rootFile to refer to for versions.json                                                                     | `string` |  **no**  | package.json | 
 
 <br /><br />
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
 	"name": "typedoc-plugin-versions",
 	"version": "0.2.3",
 	"description": "It keeps track of your document builds and provides a select menu for versions",
-	"main": "src/index",
+	"main": "dist/src/index",
 	"scripts": {
 		"test": "prettier -c . && nyc mocha",
 		"build": "npx tsc && node ./build.js",
 		"docs": "typedoc",
-		"docs:build": "tsc && typedoc"
+		"docs:build": "tsc && typedoc",
+                "prepare": "npx tsc && node ./build.js"
 	},
 	"repository": {
 		"type": "git",

--- a/src/etc/utils.ts
+++ b/src/etc/utils.ts
@@ -46,7 +46,8 @@ export function refreshMetadata(
 	metadata: metadata,
 	docRoot: string,
 	stable = 'auto',
-	dev = 'auto'
+	dev = 'auto',
+	rootFile = 'package.json'
 ): metadata {
 	const validate = (v: string) => (v === 'auto' ? v : getSemanticVersion(v));
 	const vStable = validate(stable);
@@ -54,7 +55,8 @@ export function refreshMetadata(
 
 	const versions = refreshMetadataVersions(
 		[...(metadata.versions ?? []), metadata.stable, metadata.dev],
-		docRoot
+		docRoot,
+		rootFile
 	);
 
 	return {
@@ -70,7 +72,11 @@ export function refreshMetadata(
  * @param docRoot The path to the docs root.
  * @returns A distinct array of {@link version versions}, sorted in descending order.
  */
-export function refreshMetadataVersions(versions: version[], docRoot: string) {
+export function refreshMetadataVersions(
+	versions: version[],
+	docRoot: string,
+	rootFile
+) {
 	return (
 		[
 			// metadata versions
@@ -95,7 +101,7 @@ export function refreshMetadataVersions(versions: version[], docRoot: string) {
 			...getVersions(getPackageDirectories(docRoot)),
 
 			// package.json version
-			getSemanticVersion(),
+			getSemanticVersion(getPackageVersion(rootFile)),
 
 			// stable and dev symlinks
 			getSymlinkVersion('stable', docRoot),
@@ -438,3 +444,9 @@ export const verRegex = /^(v\d+|\d+).\d+.\d+/;
  * regex for matching semantic minor version
  */
 export const minorVerRegex = /^(v\d+|\d+).\d+$/;
+
+function getPackageVersion(rootFile: string) {
+	const packagePath = path.join(process.cwd(), rootFile);
+	const pack = fs.readJSONSync(packagePath);
+	return pack.version;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,12 @@ export function load(app: Application) {
 			domLocation: 'false',
 		} as versionsOptions,
 	});
+	app.options.addDeclaration({
+		help: 'Root file',
+		name: 'rootFile',
+		type: ParameterType.String,
+		defaultValue: 'package.json',
+	});
 
 	const vOptions = vUtils.getVersionsOptions(app) as versionsOptions;
 
@@ -58,7 +64,8 @@ export function load(app: Application) {
 			vUtils.loadMetadata(rootPath),
 			rootPath,
 			vOptions.stable,
-			vOptions.dev
+			vOptions.dev,
+			vOptions.rootFile
 		);
 
 		vUtils.makeAliasLink(

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface versionsOptions {
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.
 	 */
 	domLocation?: validLocation | 'false';
+	rootFile?: string | 'package.json';
 }
 export type version = `v${string}`;
 


### PR DESCRIPTION
Currently, plugin loads the `version` key from `package.json` in the root repostiory. 

This change adds an additional typedoc option that allows the user to specify `rootPackageVersion`like `typedoc . --rootPackageVersion 2.2.0`. This means I can retrieve version from whatever source I want (not only packageJson). 

My scenario was that I have a monorepo managed by lerna with [Fixed/Locked mode](https://lerna.js.org/docs/features/version-and-publish#fixedlocked-mode-default). Hence, the `lerna.json` (not the `package.json`) contained the `version` tag, hence, I needed a flexible way to pass in `version`